### PR TITLE
Allow disabling listener on ctrl/alt

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,13 @@ We have mods based on this to swap the background with:
 
 Interactively move your camera around with arrow keys `ctrl+arrowkeys`
 Resize the cropped frame using `ctrl+shift+arrowkeys`
-You can disable this control by defining the environment variable `LISTEN_CTRL=False`.
+You can disable this control by defining the environment variable `PAN_CONTROL=False`.
 
 ### Padding
 
 Interactively pad your camera output with arrow keys `alt+arrowkeys` while keeping the output
 framesize fixed.
-You can disable this control by defining the environment variable `LISTEN_ALT=False`.
+You can disable this control by defining the environment variable `PADDING_CONTROL=False`.
 
 #### Record & Replay
 
@@ -132,9 +132,9 @@ used.
 which directly affects picture quality and FPS. If you're looking to get higher a resolution or FPS
 out of your webcam it's crucial to inspect your camera and driver capabilities and set the appropriate format here.
 
-- `LISTEN_CTRL`[Default True]: Set to False to disable panning/resizing with `ctrl+arrowkeys/ctrl+shift+arrowkeys`.
+- `PAN_CONTROL` [Default True]: Set to False to disable panning/resizing with `ctrl+arrowkeys/ctrl+shift+arrowkeys`.
 
-- `LISTEN_ALT`[Default True]: Set to False to disable padding with `alt+arrowkeys`.
+- `PADDING_CONTROL` [Default True]: Set to False to disable padding with `alt+arrowkeys`.
 
 
 

--- a/README.md
+++ b/README.md
@@ -30,11 +30,13 @@ We have mods based on this to swap the background with:
 
 Interactively move your camera around with arrow keys `ctrl+arrowkeys`
 Resize the cropped frame using `ctrl+shift+arrowkeys`
+You can disable this control by defining the environment variable `LISTEN_CTRL=False`.
 
 ### Padding
 
 Interactively pad your camera output with arrow keys `alt+arrowkeys` while keeping the output
 framesize fixed.
+You can disable this control by defining the environment variable `LISTEN_ALT=False`.
 
 #### Record & Replay
 
@@ -129,6 +131,10 @@ used.
 - `IN_FORMAT`: input video format. This dictates the requested video format from the input video device (webcam)
 which directly affects picture quality and FPS. If you're looking to get higher a resolution or FPS
 out of your webcam it's crucial to inspect your camera and driver capabilities and set the appropriate format here.
+
+- `LISTEN_CTRL`[Default True]: Set to False to disable panning/resizing with `ctrl+arrowkeys/ctrl+shift+arrowkeys`.
+
+- `LISTEN_ALT`[Default True]: Set to False to disable padding with `alt+arrowkeys`.
 
 
 

--- a/src/webcam_mods/config.py
+++ b/src/webcam_mods/config.py
@@ -26,5 +26,5 @@ ERROR_IMAGE = data_root / "errors" / "xp.jpg"
 
 ON_DEMAND = os.getenv("ON_DEMAND") == "True"
 
-LISTEN_CTRL = os.getenv("LISTEN_CTRL", "True") == "True"
-LISTEN_ALT = os.getenv("LISTEN_ALT", "True") == "True"
+PAN_CONTROL = os.getenv("PAN_CONTROL", "True") == "True"
+PADDING_CONTROL = os.getenv("PADDING_CONTROL", "True") == "True"

--- a/src/webcam_mods/config.py
+++ b/src/webcam_mods/config.py
@@ -25,3 +25,6 @@ DEFAULT_BG_IMAGE = data_root / "bg.jpg"
 ERROR_IMAGE = data_root / "errors" / "xp.jpg"
 
 ON_DEMAND = os.getenv("ON_DEMAND") == "True"
+
+LISTEN_CTRL = os.getenv("LISTEN_CTRL", "True") == "True"
+LISTEN_ALT = os.getenv("LISTEN_ALT", "True") == "True"

--- a/src/webcam_mods/uses/interactive_controls.py
+++ b/src/webcam_mods/uses/interactive_controls.py
@@ -1,4 +1,4 @@
-from webcam_mods.config import IN_HEIGHT, IN_WIDTH, LISTEN_ALT, LISTEN_CTRL
+from webcam_mods.config import IN_HEIGHT, IN_WIDTH, PADDING_CONTROL, PAN_CONTROL
 from webcam_mods.mods.video_mods import is_crop_valid
 from webcam_mods.utils.cli_input import inp
 from loguru import logger
@@ -9,9 +9,9 @@ cur_keys = set()
 JUMP = 10  # pixels
 target_keys = set()  # currently listening keys
 # avoid always engaging these controls
-if LISTEN_CTRL:
+if PAN_CONTROL:
     target_keys.add(Key.ctrl)
-if LISTEN_ALT:
+if PADDING_CONTROL:
     target_keys.add(Key.alt)
 
 cf = Config()

--- a/src/webcam_mods/uses/interactive_controls.py
+++ b/src/webcam_mods/uses/interactive_controls.py
@@ -1,4 +1,4 @@
-from webcam_mods.config import IN_HEIGHT, IN_WIDTH
+from webcam_mods.config import IN_HEIGHT, IN_WIDTH, LISTEN_ALT, LISTEN_CTRL
 from webcam_mods.mods.video_mods import is_crop_valid
 from webcam_mods.utils.cli_input import inp
 from loguru import logger
@@ -7,7 +7,12 @@ from webcam_mods.utils.config import Config
 
 cur_keys = set()
 JUMP = 10  # pixels
-
+target_keys = set()  # currently listening keys
+# avoid always engaging these controls
+if LISTEN_CTRL:
+    target_keys.add(Key.ctrl)
+if LISTEN_ALT:
+    target_keys.add(Key.alt)
 
 cf = Config()
 
@@ -15,7 +20,6 @@ cf = Config()
 def on_press(key):
     global cf, cur_keys
     cur_keys.add(key)
-    target_keys = [Key.ctrl, Key.alt]
     if not any(key in cur_keys for key in target_keys):
         return
     if Key.ctrl in cur_keys:
@@ -79,5 +83,4 @@ def on_release(key):
         cur_keys.remove(key)
 
 
-# TODO avoid always engaging these
 key_listener = Listener(on_press=on_press, on_release=on_release)


### PR DESCRIPTION
This PR allows disabling panning/resizing with ctrl/alt through environment variables.
By default, the tool automatically sets the pan/size while I'm editing code, which is distracting during meetings, so I wanted to disable it. Not sure if you have auto-tests, I tested it myself with print statements and by observing the behavior using ffplay.

Default functionality: `VIDEO_IN=1 webcam_mods bg-blur`
Disable listeners: `LISTEN_CTRL=False LISTEN_ALT=False webcam_mods bg-blur`